### PR TITLE
Improve matching with new Plex movie scanner

### DIFF
--- a/plex/datastore.go
+++ b/plex/datastore.go
@@ -134,11 +134,11 @@ func getPreferredExternalGuid(externalGuids string) (string, error) {
 			return fmt.Sprintf("com.plexapp.agents.the%s", guid), nil
 		}
 
-		if strings.HasPrefix(guid, "imdb://tt") {
+		if strings.HasPrefix(guid, "tmdb://") {
 			return fmt.Sprintf("com.plexapp.agents.%s", guid), nil
 		}
 
-		if strings.HasPrefix(guid, "tmdb://") {
+		if strings.HasPrefix(guid, "imdb://tt") {
 			preferredGuid = fmt.Sprintf("com.plexapp.agents.%s", guid)
 		}
 

--- a/plex/datastore.go
+++ b/plex/datastore.go
@@ -139,7 +139,7 @@ func getPreferredExternalGuid(externalGuids string) (string, error) {
 		}
 
 		if strings.HasPrefix(guid, "tmdb://") {
-			return fmt.Sprintf("com.plexapp.agents.%s", guid), nil
+			preferredGuid = fmt.Sprintf("com.plexapp.agents.%s", guid)
 		}
 
 	}
@@ -148,6 +148,7 @@ func getPreferredExternalGuid(externalGuids string) (string, error) {
 		return "", fmt.Errorf("unable to determine preferred external guids: %v", externalGuids)
 	}
 
+	return preferredGuid, nil
 }
 
 //goland:noinspection ALL

--- a/plex/datastore.go
+++ b/plex/datastore.go
@@ -134,19 +134,20 @@ func getPreferredExternalGuid(externalGuids string) (string, error) {
 			return fmt.Sprintf("com.plexapp.agents.the%s", guid), nil
 		}
 
-		switch {
-		case strings.HasPrefix(guid, "imdb://tt"):
-			preferredGuid = fmt.Sprintf("com.plexapp.agents.%s", guid)
-		case strings.HasPrefix(guid, "tmdb://") && preferredGuid == "":
-			preferredGuid = fmt.Sprintf("com.plexapp.agents.%s", guid)
+		if strings.HasPrefix(guid, "imdb://tt") {
+			return fmt.Sprintf("com.plexapp.agents.%s", guid), nil
 		}
+
+		if strings.HasPrefix(guid, "tmdb://") {
+			return fmt.Sprintf("com.plexapp.agents.%s", guid), nil
+		}
+
 	}
 
 	if preferredGuid == "" {
 		return "", fmt.Errorf("unable to determine preferred external guids: %v", externalGuids)
 	}
 
-	return preferredGuid, nil
 }
 
 //goland:noinspection ALL

--- a/plex/datastore.go
+++ b/plex/datastore.go
@@ -135,7 +135,7 @@ func getPreferredExternalGuid(externalGuids string) (string, error) {
 		}
 
 		switch {
-		case strings.HasPrefix(guid, "imdb://"):
+		case strings.HasPrefix(guid, "imdb://tt"):
 			preferredGuid = fmt.Sprintf("com.plexapp.agents.%s", guid)
 		case strings.HasPrefix(guid, "tmdb://") && preferredGuid == "":
 			preferredGuid = fmt.Sprintf("com.plexapp.agents.%s", guid)

--- a/pvrs/radarr/library.go
+++ b/pvrs/radarr/library.go
@@ -65,6 +65,7 @@ func (c *Client) GetLibraryItems() (map[string]plexarr.PvrItem, error) {
 
 		if item.TmdbId != nil && *item.TmdbId != 0 {
 			guids = append(guids, fmt.Sprintf("com.plexapp.agents.themoviedb://%d", *item.TmdbId))
+			guids = append(guids, fmt.Sprintf("com.plexapp.agents.tmdb://%d", *item.TmdbId))
 		}
 
 		if len(guids) == 0 {


### PR DESCRIPTION
Right now plexarr seems to prefer the `imdb://` guid, however it keeps on looking...Plex seems to store multiple `imdb://` for some movies with either bogus info or an old/wrong imdb id, in my sample case the one that radarr prefers is always first in Plex.

But since we are mainly dealing with radarr which always has an tmdb id (imdb id could be missing), I suggest we prefer the `tmdb://` instead.

Because the `tmdb://` wasn't being generated for radarr pvr, I added that too.

PS: the code probably be improved or have unforeseen side effects for stuff I didn't even think of, but on my setup it seems to be better at not trying to keep on rematching the same stuff over and over.....